### PR TITLE
#167733822  Remove Multi one-way trip request anomaly

### DIFF
--- a/src/helpers/commonHelper.js
+++ b/src/helpers/commonHelper.js
@@ -22,13 +22,13 @@ class CommonHelper {
   static generateTrips(request, id) {
     const body = Object.entries(request);
     const Trips = [];
-    const obj = {};
     const multiCity = body.filter(el => el[0] === 'from'
     || el[0] === 'to'
     || el[0] === 'departureDate'
     || el[0] === 'accommodation');
 
     while (multiCity[0][1].length > 0) {
+      const obj = {};
       multiCity.map(el => {
         // eslint-disable-next-line prefer-destructuring
         obj[el[0]] = el[1][0];


### PR DESCRIPTION
### What does this PR do?
 Previously, when a multi-city request is made. One Trip is created multiple times while the others are discarded.
This PR fixes that issue as a user is now able to create a multi-city request and have all his/her trips created
#### Description of Task to be completed?
Check the generateTrips function in the src/helpers/commonHelper file
Change the scope of the 'obj' constant created.
#### How should this be manually tested?
Make a post request on your local machine to localhost:{PORT_NUMBER}/api/v1/request
Make sure you set your headers using "Authorization": "Bearer {token}
Set your request object as follows: 
{
  "passposrtName": "Ferguson",
  "reason": "Travel",
  "type": "multi-city",
  "userId": 2,
  "managerId": 1,
  "from": ["Lagos", "Dubai"],
  "to": ["Dubai", "Mumbai"],
  "accommodation": ["Burj Khalifa", "Hotel Mumbai"],
  "departureDate": ["2018-03-29T13:34:00.000", "2018-07-29T13:34:00.000"]
}
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[https://www.pivotaltracker.com/story/show/167733822](https://www.pivotaltracker.com/story/show/167733822)
[https://www.pivotaltracker.com/story/show/167733818](https://www.pivotaltracker.com/story/show/167733818)
[https://www.pivotaltracker.com/story/show/167733819](https://www.pivotaltracker.com/story/show/167733819)
#### Screenshots (if appropriate)
![Bug_Fix](https://user-images.githubusercontent.com/47524585/64172175-46130a00-ce4c-11e9-84bc-5d0ccd0332a6.PNG)
#### Questions:
N/A