### PR TITLE
#167733828 A Manager Can Approve/Rejects Requests

### DIFF
--- a/src/controllers/request.js
+++ b/src/controllers/request.js
@@ -42,7 +42,7 @@ export default class RequestController {
       const {
         reason,
         passportName,
-        managerId,
+        lineManagerId,
         type,
         from,
         to,
@@ -55,7 +55,7 @@ export default class RequestController {
         reason,
         type,
         passportName,
-        managerId,
+        lineManagerId,
         userId
       });
 
@@ -105,14 +105,14 @@ export default class RequestController {
           id: requestId
         }
       });
-      if (request.managerId === requestingManagerId) {
-        const status = req.body.approved ? 'accepted' : 'rejected';
-        const updatedRequest = await Request.update({ status }, {
+      if (request.lineManagerId === requestingManagerId) {
+        const status = req.body.approved ? 'approved' : 'rejected';
+        await Request.update({ status }, {
           where: {
             id: requestId
           }
         });
-        res.status(200).json({ status: 200, data: updatedRequest });
+        res.status(200).json({ status: 200, data: status });
       } else {
         res.status(401).json({ status: 401, error: 'You are not the manager of the user' });
       }

--- a/src/controllers/request.js
+++ b/src/controllers/request.js
@@ -85,7 +85,38 @@ export default class RequestController {
 
       res.status(201).json({ status: 201, data: requestSummary });
     } catch (error) {
-      console.log('REQUES=>', error);
+      res.status(500).json({ status: 500, error });
+    }
+  }
+
+  /**
+   * @param {Object} req
+   * @param {Object} res
+   * @returns {Object} res (server response)
+   * @description rejects/approves a travel request
+   */
+  static async updateStatus(req, res) {
+    const requestingManagerId = req.user.id;
+    const { requestId } = req.params;
+    try {
+      // Check if the person making the update is the manager tied to the request
+      const request = await Request.findOne({
+        where: {
+          id: requestId
+        }
+      });
+      if (request.managerId === requestingManagerId) {
+        const status = req.body.approved ? 'accepted' : 'rejected';
+        const updatedRequest = await Request.update({ status }, {
+          where: {
+            id: requestId
+          }
+        });
+        res.status(200).json({ status: 200, data: updatedRequest });
+      } else {
+        res.status(401).json({ status: 401, error: 'You are not the manager of the user' });
+      }
+    } catch (error) {
       res.status(500).json({ status: 500, error });
     }
   }

--- a/src/database/migrations/20190820122711-create-user.js
+++ b/src/database/migrations/20190820122711-create-user.js
@@ -59,7 +59,7 @@ module.exports = {
     picture: {
       type: Sequelize.JSON
     },
-    lineManagerId: {
+    managerId: {
       type: Sequelize.INTEGER,
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE',

--- a/src/database/migrations/20190820122711-create-user.js
+++ b/src/database/migrations/20190820122711-create-user.js
@@ -59,13 +59,15 @@ module.exports = {
     picture: {
       type: Sequelize.JSON
     },
-    managerId: {
+    lineManagerId: {
       type: Sequelize.INTEGER,
+      allowNull: true,
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE',
       references: {
         model: 'Users',
-        key: 'id'
+        key: 'id',
+        as: 'lineManagerId',
       }
     },
     createdAt: {

--- a/src/database/migrations/20190827211052-create-request.js
+++ b/src/database/migrations/20190827211052-create-request.js
@@ -24,14 +24,14 @@ module.exports = {
       type: Sequelize.STRING,
       allowNull: false,
     },
-    managerId: {
+    lineManagerId: {
       type: Sequelize.INTEGER,
       onDelete: 'SET NULL',
       allowNull: true,
       references: {
         model: 'Users',
         key: 'id',
-        as: 'managerId',
+        as: 'lineManagerId',
       },
     },
     status: {

--- a/src/database/migrations/20190827211052-create-request.js
+++ b/src/database/migrations/20190827211052-create-request.js
@@ -26,7 +26,13 @@ module.exports = {
     },
     managerId: {
       type: Sequelize.INTEGER,
+      onDelete: 'SET NULL',
       allowNull: true,
+      references: {
+        model: 'Users',
+        key: 'id',
+        as: 'managerId',
+      },
     },
     status: {
       type: Sequelize.STRING,

--- a/src/middlewares/Validations/validateTripStatus.js
+++ b/src/middlewares/Validations/validateTripStatus.js
@@ -1,0 +1,22 @@
+/* eslint-disable no-mixed-operators */
+import errorResponse from '../../utils/index';
+
+export default (req, res, next) => {
+  /**
+     * @param {Object} req the trip request
+     * @param {Object} res summary of the above request
+     * @param {function} next pass control to next middleware
+     * @description Validate the user's inputs and selections
+     */
+  const { approved } = req.body;
+
+  try {
+    const errors = [];
+    if (!approved) errors.push('The parameter "approved" is missing');
+    if (typeof approved !== 'boolean') errors.push('The parameter "approved" must be a boolean');
+    if (errors.length > 0) throw new Error(errors);
+    return next();
+  } catch (error) {
+    return errorResponse(error, res, 400);
+  }
+};

--- a/src/middlewares/Validations/validateTripStatus.js
+++ b/src/middlewares/Validations/validateTripStatus.js
@@ -12,7 +12,7 @@ export default (req, res, next) => {
 
   try {
     const errors = [];
-    if (!approved) errors.push('The parameter "approved" is missing');
+    if (!Object.prototype.hasOwnProperty.call(req.body, 'approved')) errors.push('The parameter "approved" is missing');
     if (typeof approved !== 'boolean') errors.push('The parameter "approved" must be a boolean');
     if (errors.length > 0) throw new Error(errors);
     return next();

--- a/src/middlewares/index.js
+++ b/src/middlewares/index.js
@@ -1,2 +1,5 @@
+import validateTripStatus from './Validations/validateTripStatus';
+
+export const tripStatus = validateTripStatus;
 export { checkToken, checkVerified } from './auth';
 export { blob } from './blob';

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -122,7 +122,7 @@ const UserDefinition = (sequelize, DataTypes) => {
     // Associations can be defined here
     const user = this;
     user.belongsTo(models.User, {
-      as: 'lineManager',
+      as: 'managerId', // changed from lineManager to managerId
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE'
     });

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -122,7 +122,7 @@ const UserDefinition = (sequelize, DataTypes) => {
     // Associations can be defined here
     const user = this;
     user.belongsTo(models.User, {
-      as: 'managerId', // changed from lineManager to managerId
+      foreignKey: 'lineManagerId', // changed from lineManager to lineManagerId
       onDelete: 'SET NULL',
       onUpdate: 'CASCADE'
     });

--- a/src/models/request.js
+++ b/src/models/request.js
@@ -8,10 +8,6 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
-    managerId: {
-      type: DataTypes.INTEGER,
-      allowNull: true,
-    },
     status: {
       type: DataTypes.STRING,
       defaultValue: 'Open',
@@ -32,7 +28,7 @@ export default (sequelize, DataTypes) => {
       onDelete: 'CASCADE',
     });
     Request.belongsTo(models.User, {
-      foreignKey: 'managerId',
+      foreignKey: 'lineManagerId',
       onDelete: 'SET NULL',
     });
   };

--- a/src/models/request.js
+++ b/src/models/request.js
@@ -31,6 +31,10 @@ export default (sequelize, DataTypes) => {
       foreignKey: 'userId',
       onDelete: 'CASCADE',
     });
+    Request.belongsTo(models.User, {
+      foreignKey: 'managerId',
+      onDelete: 'SET NULL',
+    });
   };
   return Request;
 };

--- a/src/routes/api/request.js
+++ b/src/routes/api/request.js
@@ -1,11 +1,14 @@
 import { Router } from 'express';
 import { RequestController } from '../../controllers';
 import validateTripRequest from '../../middlewares/Validations/validateTripRequest';
+import { tripStatus as validateTripStatus } from '../../middlewares/index';
 
 const router = Router();
 
 router.get('/', RequestController.getAllRequests);
 
 router.post('/', validateTripRequest, RequestController.createTrip);
+
+router.patch('/:requestId/status', validateTripStatus, RequestController.updateStatus);
 
 export default router;


### PR DESCRIPTION
#### What does this PR do?
- This PR implements the feature which enables a user's direct line Manager to accept/reject their travel request

#### Description of Task to be completed?
- create associations between the user table and the lineManagerId column
- create associations between the request and user table based on the lineManagerId as a foreign key
- implement a patch endpoint to update the status of the request
- create input validation for the endpoint
- implement a controller to handle the status update
- write unit tests

#### How should this be manually tested?
- Clone the repo and navigate to the cloned folder on the command line
- Enter the command 'npm run start-dev'
- Open postman and make a PATCH request to the endpoint 'localhost:3000/api/v1/request/:requestId/status'
- In the request body, there should a parameter named 'approved'. This can only be either true or false, depending on if you want to accept/reject the request.
- Before all this is done Two users should be registered on the application and one of the users is made the lineManager of the other user.
- A travel request should be made with the normal user after signing in.
- The lineManager can then sign in and make a request to approve/reject the travel request just created

#### What are the relevant pivotal tracker stories?
- #167733828