### PR TITLE
#167733834 Delete a comment (paranoid delete)

### DIFF
--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -166,7 +166,7 @@ class AuthController extends CommonHelper {
       const message = `<p>You're almost there. To finish resetting your password, 
       please click on this link <a href = '${link}'>Reset Password</a>.</p>`;
       await sendVerificationMail(email, subject, message);
-      const response = 'A verification has been sent to your email. Kindly follow that link to reset your password';
+      const response = 'A verification link has been sent to your email. Kindly follow that link to reset your password';
       return res.status(200).json({
         status: 200,
         data: { message: response, token }

--- a/src/controllers/comment.js
+++ b/src/controllers/comment.js
@@ -30,4 +30,42 @@ export default class CommentController {
       res.status(500).json({ status: 'error', error: error.message });
     }
   }
+
+  /**
+   * @param {Object} req the unwanted comment to be removed
+   * @param {Object} res successfully deleted comment or failure object
+   * @returns {void}
+   * @description gives a user ability to delete THEIR unwanted comment(s) about a request.
+   */
+  static async pseudoDeleteComment(req, res) {
+    const { commentId } = req.params;
+    const commentOwner = req.user.id;
+    try {
+      const comment = await Comment.findOne({
+        where: {
+          id: commentId
+        }
+      });
+      if (comment.userId !== commentOwner) {
+        return res.status(401).json({
+          status: 'error',
+          message: 'you are not the owner of this comment'
+        });
+      }
+      const deletedAt = Date.now();
+      await Comment.update({ deletedAt }, {
+        where: {
+          id: commentId
+        }
+      });
+      res.status(200).json({
+        status: 'success',
+        data: {
+          message: 'Comment succesfully deleted'
+        }
+      });
+    } catch (error) {
+      res.status(500).json({ status: 'error', error: error.message });
+    }
+  }
 }

--- a/src/database/migrations/20190907125847-add-deletedAt-column-to-comment.js
+++ b/src/database/migrations/20190907125847-add-deletedAt-column-to-comment.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: (queryInterface, Sequelize) => queryInterface.addColumn(
+    'Comments', 'deletedAt',
+    {
+      type: Sequelize.DATE,
+      allowNull: true
+    }
+  ),
+
+  down: (queryInterface) => queryInterface.removeColumn('Comments', 'deletedAt')
+};

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -626,8 +626,103 @@ module.exports = {
         responses: {
           200: {
             description: 'Permissions have been set for a role',
-          201: {
-            description: 'successful operation; comment created',
+            201: {
+              description: 'successful operation; comment created',
+              schema: {
+                type: 'object',
+                properties: {
+                  status: {
+                    type: 'string'
+                  },
+                  data: {
+                    type: 'object',
+                    properties: {
+                      commentBody: {
+                        type: 'string',
+                        example: 'test commentitis'
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            400: {
+              description: 'Bad request',
+              schema: {
+                type: 'object',
+                properties: {
+                  status: {
+                    type: 'string'
+                  },
+                  error: {
+                    type: 'string'
+                  }
+                }
+              }
+            },
+            401: {
+              description: 'Unauthorized',
+              schema: {
+                type: 'object',
+                properties: {
+                  status: {
+                    type: 'integer'
+                  },
+                  error: {
+                    type: 'string'
+                  }
+                }
+              }
+            },
+            403: {
+              description: 'Forbidden request',
+              schema: {
+                type: 'object',
+                properties: {
+                  status: {
+                    type: 'string'
+                  },
+                  error: {
+                    type: 'string'
+                  }
+                }
+              }
+            },
+            404: {
+              description: 'Resource endpoint does not exist',
+              description: 'Bad Request: Some fields are empty or invalid data format',
+              schema: {
+                type: 'object',
+                properties: {
+                  status: {
+                    type: 'string'
+                  },
+                  error: {
+                    type: 'string'
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+    },
+    '/request/requestId/comment/:commentId': {
+      delete: {
+        tags: ['comment'],
+        summary: 'Allows a user to delete their comment(s)',
+        produces: ['application/json'],
+        parameters: [
+          {
+            name: 'Authorization',
+            in: 'headers',
+            description: 'Bearer token',
+            type: 'string'
+          }
+        ],
+        responses: {
+          200: {
+            description: 'User has successfully deleted their comment',
             schema: {
               type: 'object',
               properties: {
@@ -636,64 +731,12 @@ module.exports = {
                 },
                 data: {
                   type: 'object'
-                },
-                data: {
-                  type: 'object',
-                  properties: {
-                    commentBody: {
-                      type: 'string',
-                      example: 'test commentitis'
-                    }
-                  }
-                }
-              }
-            }
-          },
-          400: {
-            description: 'Bad request',
-            schema: {
-              type: 'object',
-              properties: {
-                status: {
-                  type: 'string'
-                },
-                error: {
-                  type: 'string'
                 }
               }
             }
           },
           401: {
-            description: 'Unauthorized',
-            schema: {
-              type: 'object',
-              properties: {
-                status: {
-                  type: 'integer'
-                },
-                error: {
-                  type: 'string'
-                }
-              }
-            }
-          },
-          403: {
-            description: 'Forbidden request',
-            schema: {
-              type: 'object',
-              properties: {
-                status: {
-                  type: 'string'
-                },
-                error: {
-                  type: 'string'
-                }
-              }
-            }
-          },
-          404: {
-            description: 'Resource endpoint does not exist',
-            description: 'Bad Request: Some fields are empty or invalid data format',
+            description: 'Unauthorized, "you are not the owner of this comment"',
             schema: {
               type: 'object',
               properties: {
@@ -708,7 +751,6 @@ module.exports = {
           }
         }
       }
-    },
     },
     '/role': {
       patch: {
@@ -829,124 +871,124 @@ module.exports = {
                 delete: {
                   type: 'boolean',
                   example: 'false'
-                }, 
+                },
               },
             },
           },
         ],
       },
-    },            
-  definitions: {
-    SendEmail: {
-      type: 'object',
-      properties: {
-        email: {
-          type: 'string',
-          example: 'fergusoniyara@gmail.com',
-        }
-      },
     },
-    ResetPassword: {
-      type: 'object',
-      properties: {
-        password: {
-          type: 'string',
-          example: 'Password@2018',
+    definitions: {
+      SendEmail: {
+        type: 'object',
+        properties: {
+          email: {
+            type: 'string',
+            example: 'fergusoniyara@gmail.com',
+          }
         },
-        confirmPassword: {
-          type: 'string',
-          example: 'Password@2018',
-        }
       },
-    },
-    MessageSentResponse: {
-      type: 'object',
-      properties: {
-        status: {
-          type: 'integer',
-          example: 200,
+      ResetPassword: {
+        type: 'object',
+        properties: {
+          password: {
+            type: 'string',
+            example: 'Password@2018',
+          },
+          confirmPassword: {
+            type: 'string',
+            example: 'Password@2018',
+          }
         },
-        data: {
-          type: 'object',
-          properties: {
-            message: {
-              type: 'string',
-              example: 'A verification has been sent to your email. Kindly follow that link to reset your password',
-            },
-            token: {
-              type: 'string',
-              example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Iml5YXJhZmVyZ3Vzb25AZ21haWwuY29tIiwiaWF0IjoxNTY2NDAzMTA3LCJleHAiOjE1NjY0ODk1MDd9.jDq8clsqJtTBN0-PKLJdu0U2GihHDCtn5P90aO0CHAs',
+      },
+      MessageSentResponse: {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'integer',
+            example: 200,
+          },
+          data: {
+            type: 'object',
+            properties: {
+              message: {
+                type: 'string',
+                example: 'A verification has been sent to your email. Kindly follow that link to reset your password',
+              },
+              token: {
+                type: 'string',
+                example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6Iml5YXJhZmVyZ3Vzb25AZ21haWwuY29tIiwiaWF0IjoxNTY2NDAzMTA3LCJleHAiOjE1NjY0ODk1MDd9.jDq8clsqJtTBN0-PKLJdu0U2GihHDCtn5P90aO0CHAs',
+              },
             },
           },
         },
       },
-    },
-    PasswordResetResponse: {
-      type: 'object',
-      properties: {
-        status: {
-          type: 'integer',
-          example: 200,
-        },
-        data: {
-          type: 'object',
-          properties: {
-            message: {
-              type: 'string',
-              example: 'Password reset successful',
-            }
+      PasswordResetResponse: {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'integer',
+            example: 200,
+          },
+          data: {
+            type: 'object',
+            properties: {
+              message: {
+                type: 'string',
+                example: 'Password reset successful',
+              }
+            },
           },
         },
       },
-    },
-    EmailNotFoundResponse: {
-      type: 'object',
-      properties: {
-        status: {
-          type: 'integer',
-          example: 404,
+      EmailNotFoundResponse: {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'integer',
+            example: 404,
+          },
+          error: {
+            type: 'string',
+            example: 'No User with the provided email'
+          },
         },
-        error: {
-          type: 'string',
-          example: 'No User with the provided email'
+      },
+      PasswordResetValidationResponse: {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'integer',
+            example: 400,
+          },
+          error: {
+            type: 'string',
+            example: 'Password must contain at least one number'
+          },
+        },
+      },
+      EmailInvalidResponse: {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'integer',
+            example: 400,
+          },
+          error: {
+            type: 'string',
+            example: 'Invalid email supplied'
+          },
+        },
+      },
+      Comment: {
+        type: 'object',
+        properties: {
+          commentBody: {
+            type: 'string',
+            example: 'I just have to be granted this request, let me go and chill',
+          }
         },
       },
     },
-    PasswordResetValidationResponse: {
-      type: 'object',
-      properties: {
-        status: {
-          type: 'integer',
-          example: 400,
-        },
-        error: {
-          type: 'string',
-          example: 'Password must contain at least one number'
-        },
-      },
-    },
-    EmailInvalidResponse: {
-      type: 'object',
-      properties: {
-        status: {
-          type: 'integer',
-          example: 400,
-        },
-        error: {
-          type: 'string',
-          example: 'Invalid email supplied'
-        },
-      },
-    },
-    Comment: {
-      type: 'object',
-      properties: {
-        commentBody: {
-          type: 'string',
-          example: 'I just have to be granted this request, let me go and chill',
-        }
-      },
-    },
-  },
   }
 };

--- a/src/models/comment.js
+++ b/src/models/comment.js
@@ -4,7 +4,13 @@ export default (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: false,
     },
-  }, {});
+    deletedAt: {
+      type: DataTypes.DATE,
+      allowNull: true
+    }
+  }, {
+    paranoid: true
+  });
 
   Comment.associate = (models) => {
     Comment.belongsTo(models.Request, {

--- a/src/routes/api/comment.js
+++ b/src/routes/api/comment.js
@@ -6,5 +6,6 @@ import validateComment from '../../middlewares/validateComment';
 const router = Router();
 
 router.post('/:requestId/comment', validateComment, CommentController.postComment);
+router.delete('/:requestId/comment/:commentId', CommentController.pseudoDeleteComment);
 
 export default router;

--- a/src/test/comment.test.js
+++ b/src/test/comment.test.js
@@ -8,7 +8,10 @@ import helper from '../helpers/jwtHelper';
 const { generateToken } = helper;
 
 let userId;
-let token;
+// let secondUserId;
+let requestId;
+let firstToken;
+let secondToken;
 
 dotenv.config();
 
@@ -22,99 +25,145 @@ const { expect } = chai;
 chai.should();
 chai.use(chaiHttp);
 
-describe('POST /api/v1/request/:requestId/comment', () => {
-  let requestId;
-  describe('Creating a new newcomment', () => {
-    before((done) => {
-      // Create lineManager user
-      User.create({
-        firstName: 'John',
-        lastName: 'Neo',
-        email: 'test@domain.com',
-        password: 'tester123',
-        isVerified: true
-      }).then(user => {
-        userId = user.id;
-        token = generateToken({
-          id: userId,
-          email: user.email,
-          isVerified: user.isVerified
-        });
-        Request.create({
-          userId,
-          passportName: 'normal User',
-          reason: 'test reason',
-          lineManagerId: 1,
-          status: 'pending',
-          type: 'one-way',
-        }).then(newRequest => {
-          Trip.create({
-            requestId: newRequest.id,
-            from: 'lagos',
-            to: 'kampala',
-            departureDate: '2019-08-09 13:00',
-            accommodation: 'hilton'
-          }).then(() => {
-            done();
-          });
+const secondSignup = {
+  firstName: 'Fred',
+  lastName: 'Noble',
+  email: 'besta@domain.com',
+  password: 'tester123',
+  isVerified: true
+};
+
+
+before((done) => {
+  // Create lineManager user
+  User.create({
+    firstName: 'John',
+    lastName: 'Neo',
+    email: 'test@domain.com',
+    password: 'tester123',
+    isVerified: true
+  }).then((user) => {
+    userId = user.id;
+    firstToken = generateToken({
+      id: userId,
+      email: user.email,
+      isVerified: user.isVerified
+    });
+    User.create(secondSignup)
+      .then((user2) => {
+        secondToken = generateToken({
+          id: user2.id,
+          email: user2.email,
+          isVerified: user2.isVerified
         });
       });
-    });
 
-    it('Should return details of the new comments on a request', (done) => {
-      chai.request(server)
-        .post('/api/v1/request/1/comment')
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          commentBody: 'test comments',
-          userId,
-          requestId
-        })
-        .end((err, res) => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(err).to.be.null;
-          expect(res).to.has.status(201);
-          expect(res.body).to.haveOwnProperty('status');
-          expect(res.body.status).to.equal('success');
-          expect(res.body).to.haveOwnProperty('data');
-          done();
-        });
+    Request.create({
+      userId,
+      passportName: 'normal User',
+      reason: 'test reason',
+      lineManagerId: 1,
+      status: 'pending',
+      type: 'one-way',
+    }).then((newRequest) => {
+      Trip.create({
+        requestId: newRequest.id,
+        from: 'lagos',
+        to: 'kampala',
+        departureDate: '2019-08-09 13:00',
+        accommodation: 'hilton'
+      }).then(() => {
+        done();
+      });
     });
+  });
+});
 
-    it('Should respond with error object if an empty comment is made', (done) => {
-      chai.request(server)
-        .post('/api/v1/request/1/comment')
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          commentBody: '',
-          userId,
-          requestId
-        })
-        .end((err, res) => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(res).to.has.status(400);
-          expect(res.body).to.haveOwnProperty('status');
-          expect(res.body).to.haveOwnProperty('error');
-          done();
-        });
-    });
+describe('POST /request/:requestId/comment, Creating a new newcomment', () => {
+  it('Should return details of the new comments on a request', (done) => {
+    chai.request(server)
+      .post('/api/v1/request/1/comment')
+      .set('Authorization', `Bearer ${firstToken}`)
+      .send({
+        commentBody: 'This is the comment',
+        userId,
+        requestId
+      })
+      .end((err, res) => {
+        // eslint-disable-next-line no-unused-expressions
+        expect(err).to.be.null;
+        expect(res).to.has.status(201);
+        expect(res.body).to.haveOwnProperty('status');
+        expect(res.body.status).to.equal('success');
+        expect(res.body).to.haveOwnProperty('data');
+        done();
+      });
+  });
 
-    it('Should respond with error object if a bad comment request is made', (done) => {
-      chai.request(server)
-        .post('/api/v1/request/1/comment')
-        .set('Authorization', `Bearer ${token}`)
-        .send({
-          commentBody: 1,
-          userId,
-          requestId
-        })
-        .end((err, res) => {
-          // eslint-disable-next-line no-unused-expressions
-          expect(res).to.has.status(400);
-          expect(res.body).to.haveOwnProperty('status');
-          expect(res.body).to.haveOwnProperty('error');
-          done();
-        });
-    });
+  it('Should respond with error object if an empty comment is made', (done) => {
+    chai.request(server)
+      .post('/api/v1/request/1/comment')
+      .set('Authorization', `Bearer ${firstToken}`)
+      .send({
+        commentBody: '',
+        userId,
+        requestId
+      })
+      .end((err, res) => {
+        // eslint-disable-next-line no-unused-expressions
+        expect(res).to.has.status(400);
+        expect(res.body).to.haveOwnProperty('status');
+        expect(res.body).to.haveOwnProperty('error');
+        done();
+      });
+  });
+
+  it('Should respond with error object if a bad comment request is made', (done) => {
+    chai.request(server)
+      .post('/api/v1/request/1/comment')
+      .set('Authorization', `Bearer ${firstToken}`)
+      .send({
+        commentBody: 1,
+        userId,
+        requestId
+      })
+      .end((err, res) => {
+        // eslint-disable-next-line no-unused-expressions
+        expect(res).to.has.status(400);
+        expect(res.body).to.haveOwnProperty('status');
+        expect(res.body).to.haveOwnProperty('error');
+        done();
+      });
+  });
+});
+
+describe('PSEUDO-delete /request/:requestId/comment/commentId', () => {
+  it('Should NOT ALLOW a user to delete another user\'s comment', (done) => {
+    chai.request(server)
+      .delete('/api/v1/request/1/comment/1')
+      .set('Authorization', `Bearer ${secondToken}`)
+      .end((err, res) => {
+      // eslint-disable-next-line no-unused-expressions
+        expect(res).to.has.status(401);
+        expect(res.body).to.haveOwnProperty('status');
+        expect(res.body.status).to.equal('error');
+        expect(res.body.message).to.equal('you are not the owner of this comment');
+        done();
+      });
+  });
+
+  it('Should set DeletedAt column to current date and time', (done) => {
+    chai.request(server)
+      .delete('/api/v1/request/1/comment/1')
+      .set('Authorization', `Bearer ${firstToken}`)
+      .end((err, res) => {
+        // eslint-disable-next-line no-unused-expressions
+        expect(err).to.be.null;
+        expect(res).to.has.status(200);
+        expect(res.body).to.haveOwnProperty('status');
+        expect(res.body.status).to.equal('success');
+        expect(res.body).to.haveOwnProperty('data');
+        done();
+      });
   });
 });


### PR DESCRIPTION
**What does this PR do**
-this gives a user the ability to delete only their comment(s)

**Description of task to be deleted**
-add a deletedAt column to the comment model and make it nullable
-implement the algorithm for deleting a comment  as specified on the PT board.
-ensure the endpoint DELETE /request/requestId/comment/commentId is working  as expected

**How should this be manually tested?**
-once this PR is merged , on postman, after creating a request and a comment on the request using their corresponding endpoints, 
make a DELETE request to /request/requestId/comment/commentId, and a success or error object will be will be called depending on the validity of the token
**note:** ensure a valid token of the comment owner is supplied, else 401 Err

**Any background contexts**
the comment is NOT deleted from the backend but is no longer available on the frontend.

**Relevant PT stories**
#167733834